### PR TITLE
Only use system arch to decide on etc folder path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,38 +5,50 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.10.3] - 2022-07-14
+
+### Changed
+
+-   Made EtcDirectory guess the path based on the system architecture only. 
+    It won't raise an error now if it's not found.
+
+## [0.10.2] - 2022-07-13
+
+### Added
+
+-   Added EtcDirectory class to the paths module for locating the Python
+    distribution's etc directory.
+
 ## [0.10.1] - 2019-07-08
 
 ### Changed
 
-- Added Loader and Dumper arguments to pyyaml calls as required by pyyaml 
-  version 5.1 to improve safety.
-
+-   Added Loader and Dumper arguments to pyyaml calls as required by pyyaml 
+    version 5.1 to improve safety.
 
 ## [0.10.0] - 2019-03-01
 
 ### Added
 
-- Added dummy logging configuration file to config/logging.yaml and added
-  usage example to README.
-- Added Directory.list_files method to list the files in a directory if it
-  exists.
-- Added DirectoryMap.copy_all and DirectoryMap.safe_copy_all to copy all files
-  in the source directory to the target directory.
-- Directory objects now returns their path when printed.
+-   Added dummy logging configuration file to config/logging.yaml and added
+    usage example to README.
+-   Added Directory.list_files method to list the files in a directory if it
+    exists.
+-   Added DirectoryMap.copy_all and DirectoryMap.safe_copy_all to copy all files
+    in the source directory to the target directory.
+-   Directory objects now returns their path when printed.
   
 ### Changed
 
-- Made Logger.configure_logger require the configuration dictionary as an
-  input.
+-   Made Logger.configure_logger require the configuration dictionary as an
+    input.
   
 ### Fixed
 
-- Ensured that the target directory exists when calling ReadYAML.write().
+-   Ensured that the target directory exists when calling ReadYAML.write().
 
 ## [0.9.0] - 2017-01-04
 
 ### Added
 
-- Initial import of dtocean-gui from SETIS.
-
+-   Initial import of dtocean-gui from SETIS.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@
 #---------------------------------#
 
 # version format
-version: 0.10.2.build{build}
+version: 0.10.3.build{build}
 
 environment:
   matrix:

--- a/polite/paths.py
+++ b/polite/paths.py
@@ -17,7 +17,7 @@ import shutil
 import inspect
 
 # Local imports
-from .appdirs import user_data_dir, site_data_dir
+from .appdirs import user_data_dir, site_data_dir, system
 
 class Directory(object):
 
@@ -101,19 +101,14 @@ class EtcDirectory(Directory):
     def __init__(self, *paths):
         
         def get_dir(*paths): #pylint: disable=missing-docstring
-            path = os.path.abspath(os.path.join(*paths))
-            if os.path.isdir(path): return path
-            return False
+            return os.path.abspath(os.path.join(*paths))
         
         exe_folder = os.path.dirname(sys.executable)
         
-        dir_path = get_dir(exe_folder, "etc")
-        
-        if dir_path is False:
+        if system == "win32":
+            dir_path = get_dir(exe_folder, "etc")
+        else:
             dir_path = get_dir(exe_folder, "..", "etc")
-        
-        if dir_path is False:
-            raise RuntimeError("Distribution 'etc' folder not found")
         
         dir_path = os.path.join(dir_path, *paths)
         super(EtcDirectory, self).__init__(dir_path)

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -57,11 +57,11 @@ def test_SiteDataDirectory():
 def test_EtcDirectory_win(mocker, tmp_path):
     
     exe_path = tmp_path / "python.exe"
-    etc_dir = tmp_path / "etc"
-    etc_dir.mkdir()
     
     mocker.patch('polite.paths.sys.executable',
                  new=str(exe_path))
+    mocker.patch('polite.paths.system',
+                 new='win32')
     
     test = EtcDirectory("mock")
     expected = os.path.join(str(tmp_path), "etc", "mock")
@@ -72,31 +72,16 @@ def test_EtcDirectory_win(mocker, tmp_path):
 def test_EtcDirectory_linux(mocker, tmp_path):
     
     exe_path = tmp_path / "bin" / "python"
-    etc_dir = tmp_path / "etc"
-    etc_dir.mkdir()
     
     mocker.patch('polite.paths.sys.executable',
                  new=str(exe_path))
+    mocker.patch('polite.paths.system',
+                 new='linux2')
     
     test = EtcDirectory("mock")
     expected = os.path.join(str(tmp_path), "etc", "mock")
     
     assert test.get_path() == expected
-
-
-def test_EtcDirectory_unknown(mocker, tmp_path):
-    
-    exe_path = tmp_path / "Lib" / "bin" / "python"
-    etc_dir = tmp_path / "etc"
-    etc_dir.mkdir()
-    
-    mocker.patch('polite.paths.sys.executable',
-                 new=str(exe_path))
-    
-    with pytest.raises(RuntimeError) as excinfo:
-        EtcDirectory()
-    
-    assert "'etc' folder not found" in str(excinfo)
 
 
 def test_object_path():


### PR DESCRIPTION
Made `EtcDirectory` guess the path based on the system architecture only. It won't raise an error now if the `etc` directory is not found.

Bump to version 0.10.3